### PR TITLE
CI improvements

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,12 @@
+FROM elixir:1.8.1-alpine
+
+RUN apk add --no-cache \
+        gcc \
+        libsodium-dev=1.0.16-r0 \
+        make \
+        musl-dev
+
+RUN mix local.rebar --force && \
+    mix local.hex --force
+
+WORKDIR /app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: smaximov/elixir-libsodium:1.8.1-alpine
+      - image: grappigpanda/elixir-libsodium:1.8.1-alpine
         environment:
           MIX_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,14 @@
-# Elixir CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-elixir/ for more details
 version: 2
 jobs:
   build:
     docker:
-      # specify the version here
-      - image: circleci/elixir:1.5
+      - image: smaximov/elixir-libsodium:1.8.1-alpine
+        environment:
+          MIX_ENV: test
 
     steps:
       - checkout
 
-      - run: wget https://download.libsodium.org/libsodium/releases/old/libsodium-1.0.13.tar.gz
-      - run: tar xf libsodium-1.0.13.tar.gz
-      - run: cd libsodium-1.0.13; ./configure; make; sudo make install
-
-      - run: mix local.hex --force  # install Hex locally (without prompt)
-      - run: mix local.rebar --force  # fetch a copy of rebar (without prompt)
-
-      - run: mix deps.get
+      - run: mix do deps.get --only test, compile
       - run: mix test
       - run: mix credo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,30 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          keys:
+            - v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+            - v1-mix-cache-{{ .Branch }}
+            - v1-mix-cache
+      - restore_cache:
+          keys:
+            - v1-build-cache-{{ .Branch }}
+            - v1-build-cache
       - run: mix do deps.get --only test, compile
+      - save_cache:
+          key: v1-mix-cache-{{ .Branch }}-{{ checksum "mix.lock" }}
+          paths: "deps"
+      - save_cache:
+          key: v1-mix-cache-{{ .Branch }}
+          paths: "deps"
+      - save_cache:
+          key: v1-mix-cache
+          paths: "deps"
+      - save_cache:
+          key: v1-build-cache-{{ .Branch }}
+          paths: "_build"
+      - save_cache:
+          key: v1-build-cache
+          paths: "_build"
       - run: mix test
       - run: mix credo


### PR DESCRIPTION
Use a custom executor image for CI as I suggested in [my comment](https://github.com/GrappigPanda/Paseto/issues/25#issuecomment-464065476). I also enabled caching for dependencies and build artifacts to further speed up CI. The results:

- using a custom Docker image &mdash; [33 seconds](https://circleci.com/gh/smaximov/Paseto/4);
- when the caching kick in &mdash; [19 seconds](https://circleci.com/gh/smaximov/Paseto/5).

You may want to build the executor image yourself:

1. Build and push the executor image:

    ``` bash
    $ docker build -t $username/elixir-libsodium:1.8.1-alpine .circleci
    $ docker push $username/elixir-libsodium:1.8.1-alpine
    ```

2. Change the image in `.circleci/config.yml`.

Resolves #25.