### PR TITLE
Fix 'generate_token' spec return type

### DIFF
--- a/lib/paseto.ex
+++ b/lib/paseto.ex
@@ -117,14 +117,12 @@ defmodule Paseto do
         version: "v2"
         }}
   """
-  @spec generate_token(String.t(), String.t(), String.t(), String.t()) ::
-          {:ok, String.t()} | {:error, String.t()}
+  @spec generate_token(String.t(), String.t(), String.t(), String.t()) :: String.t() | {:error, String.t()}
   def generate_token(version, purpose, payload, secret_key, footer \\ "") do
     _generate_token(version, purpose, payload, secret_key, footer)
   end
 
-  @spec _generate_token(String.t(), String.t(), binary, String.t(), String.t()) ::
-          {:ok, String.t()} | {:error, String.t()}
+  @spec _generate_token(String.t(), String.t(), binary, String.t(), String.t()) :: String.t() | {:error, String.t()}
   defp _generate_token(version, "public", payload, {_pk, sk}, footer) do
     case String.downcase(version) do
       "v2" -> V2.sign(payload, sk, footer)


### PR DESCRIPTION
Current return type: `{:ok, String.t()} | {:error, String.t()}`, but in the success case only the string is returned. I've updated the spec to reflect that. This is breaking dialyzer checks in our use of Paseto.generate_token/4.